### PR TITLE
Radius attribute for data point (fix for firefox).

### DIFF
--- a/modules/area-chart/index.js
+++ b/modules/area-chart/index.js
@@ -358,6 +358,7 @@ export default class AreaChart extends PureComponent {
           .datum(d)
           .append('circle')
           .attr('class', 'data-point')
+          .attr('r', 4)
           .style('strokeWidth', '2px')
           .style('stroke', getStroke)
           .style('fill', 'white')

--- a/modules/line-chart/index.js
+++ b/modules/line-chart/index.js
@@ -298,6 +298,7 @@ export default class LineChart extends React.Component {
           .datum(d)
           .append('circle')
           .attr('class', 'data-point')
+          .attr('r', 4)
           .style('strokeWidth', '2px')
           .style('stroke', getStroke)
           .style('fill', 'white')

--- a/modules/line-chart/static/index.js
+++ b/modules/line-chart/static/index.js
@@ -315,6 +315,7 @@ export default class LineChart extends PureComponent {
           .datum(d)
           .append('circle')
           .attr('class', 'data-point')
+          .attr('r', 4)
           .style('strokeWidth', '2px')
           .style('stroke', getStroke)
           .style('fill', 'white')


### PR DESCRIPTION
At Firefox, data points are not displayed, because Firefox does not support SVG radius as a CSS property. I added an attribute fallback.
It will not work for the hover effect of increasing the data point (only at Firefox), but it better than no data points.

Also, this PR can fix this issue: https://github.com/rma-consulting/react-easy-chart/issues/96.